### PR TITLE
Blocked resizing window to fit keyboard

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
         <activity
             android:name=".app.MainActivity"
             android:screenOrientation="portrait"
+            android:windowSoftInputMode="adjustPan"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
Fixed the issue by blocking resizing layout when keyboard is displayed. Default value of android:windowSoftInputMode is "stateUnspecified" - "Whether the soft keyboard is hidden or visible isn't specified. The system chooses an appropriate state or relies on the setting in the theme" (turns out adding animations to fragment replacing also has impact on it). 

Closes #13